### PR TITLE
fix(help): show basename of $0 in help message instead of full value

### DIFF
--- a/emacs-sandbox.sh
+++ b/emacs-sandbox.sh
@@ -68,7 +68,7 @@ function die {
 
 function usage {
     cat <<EOF
-$0 [OPTIONS] [EMACS-ARGS]
+$(basename "$0") [OPTIONS] [EMACS-ARGS]
 
 Run Emacs in a "sandbox" user-emacs-directory.  If no directory is
 specified, one is made with "mktemp -d" and removed when Emacs exits.


### PR DESCRIPTION
Personally I don't think the full invocation path to `emacs-sandbox.sh` is needed in the help message. But that's just my opinion, so feel free to disagree and ignore this PR :)